### PR TITLE
fix(docs): corrected Streamlit entry file

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ HUGGINGFACE_API_KEY=your_api_key
 **4️⃣ Run the Streamlit app**
 
 ```bash
-streamlit run app.py
+python -m streamlit run WellnessResourceHub.py
 ```
 
 ---


### PR DESCRIPTION
### Summary
Fixed incorrect startup command in README. The main entry point is `WellnessResourceHub.py`, not `app.py`.

### Why
Users encountered an error: "File does not exist: app.py".

### How to Test
1. Clone repo
2. pip install -r backend/requirements.txt
3. Run `python -m streamlit run WellnessResourceHub.py`
